### PR TITLE
Support yml extension and remove mandatory file pattern

### DIFF
--- a/example/helm_vars/another-secret.yml
+++ b/example/helm_vars/another-secret.yml
@@ -1,0 +1,52 @@
+global_secret: ENC[AES256_GCM,data:tW3e3YO0mffFQQ==,iv:cLs3C0IbhdB1aybbUIZfh8VBFEno32y/YLnJwhEq/iE=,tag:4F6PsxCj2Oxn0t49W7xfTQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2019-03-29T11:02:06Z'
+    mac: ENC[AES256_GCM,data:rDHF8C+s0WRHxsy6JKffkpwasJDp55fAxDY5WOXtz4u44bLNw/SrMDCBsYzQ1UcwxYMY+CAQINyeFyqeH5GjDPW6sJ1pmEQk0QTV8NdD/O/dDfHsXfTyFY8ZBNoIJJe8s3uMq3vm3L6BLjRJ8jHtbXwF/c3HOFYzKC+1J0X9TmE=,iv:ydQoImoP2Jt/tvOecurX7XsEIKtAGRJ6YzI1+MsMsuQ=,tag:gB8pvoRev9iProFjEga7vQ==,type:str]
+    pgp:
+    -   created_at: '2019-03-29T11:02:06Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAxYpv4YXKfBAARAAkm4oBJlVN/yMSJasC/dYJvrCAooV2P6Oljsiw+VaKzRI
+            fNP7guPGXm7HMMjgF4e9RrBH4XsVLVSEL1yjXsP4s1CoiLOMqti/MvkPDvKjLzxT
+            ATvzpD7nAs0YEnQNlf7/DHm9JAGPWjfI2UJ/oEp4ba+bMIVg4nPV47n06f31m5Ur
+            hYMxUoFdCQbxCOnMCvcbTR9UMPfWLdd0Rr4T2NUSAY8Tr1LTM+iXRTdeJKy1AAhr
+            t/mu7sDADEm9aJSIbbE8nYSIzZuN7yL02CuZZci3HGOUV71cLVeOHC8MvKx2rwf8
+            iT7L0dHwmi9mdfmIyNwKRhvzSR6RllUhfuDXB4cQ54/xnQ/7vF+YNdbJa8xl9Va/
+            G60XClMsTr3iGOWU4Q2wlM+f7RGF6Bfwek5R0vWxGc/GshB4kQAu37g/L2E/79JX
+            m8LtZJl89p1n550lioX/+pituY8zd9uTsiqn21OIT5Uk830OygBcJTQepkz5lLI5
+            c6OsuODNEvw2CJ6eHxAfG6GdW+B2spDJcJyELaKbP9zxDEK9RRC8MDxILDoOsk4I
+            ITKbx8jgeUXH6S7fRAvRDbzCLgMjKEUuEDmYO4a7d4m4Jf4htvATtmS8JPPpv5jQ
+            1exXORaScAnmkFT0haupgBAX7dsCx36xpqqPFneFgTCzH3HUVhf7IpBG+opUhFTS
+            4AHkVg6v8c/fqNfd41cKSERhG+GrLODV4PXhmzbgQuJpTjIx4HXlUXDFGDg2akB8
+            UjWODkgtSitXvY6t3koS6d1BLH2L5rTg1+Qv4s9R4rBbMsB5Ahw6v/+b4q55Ubnh
+            DrIA
+            =U903
+            -----END PGP MESSAGE-----
+        fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
+    -   created_at: '2019-03-29T11:02:06Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAxzSiC7ZHNQZARAAb699zXK7tDKBJXQRHkSWN5/plCP1S+VouTkxKYpB1uYU
+            ivNyDAbYfXnU7LMClcK+qVdpK1JPULGjxJLVQLRsg1HRwYvkY/zKkXMUz824X2Hu
+            MeXywxzsS0pwLJ4PutmTrRWRSEltxed4vgndrzxkJtw7Fxf2eh8lJcevsZGXQyW/
+            2fghXVhGnQZe/MaynPcmI8F3Wxxa+6r1WnlSL3fvICQtyAAzS8rmDM7n8Iwzh4j7
+            +zaBQ3wavYFX7lILa4JilwAku3VxZBgUh7FDxy62lZEE1giGJykW9DQaCMCdJiJh
+            5gG+yMIcjol2EQC+em//ZGcPHOR+qaG6HXUWhVFo67Gg3dKoYPXqjTFrAjg/ujja
+            utx6gxXUcOFyPFlJw7orG+P08PgshRVYT4Go3UAbSR/tjvcmyrKMRQBvF+Y1jRbb
+            y6GgCWae2lAO3wPejvFYn2yAnl9TRIZWAqet/1BJvnls+QmMCLkhLBx9l8zIA/iE
+            G2vO/R5vwC9j07UNLGSjrVvadnw51UT8efEiQOPRRhMSRe3tbq6g/2tkaRAt8PTP
+            J9SzM5BcPiGBHlrjAvJkDzmmXorEK317XZ3hPMY1326Rn37ZMenfYmCsv2Y+KN66
+            5h3tzSF2+8CeMowRjygFh5AQm0jpmHGNQkcDUfL7ewr9v/lrKJt6eGK5WnUM8VXS
+            4AHkxq+E5sc6FrwYQYc5x28W/+F82+Az4O7hlATgb+LOrE4g4D7liQNTKREiREJQ
+            N84cvTNEp7NIHr7+tJRYuNjfAO+4743gb+Rfuqf6pXHSw7R0kYE70tid4tovsGDh
+            VqIA
+            =FY1e
+            -----END PGP MESSAGE-----
+        fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0

--- a/example/helm_vars/no-secret.yaml.dec
+++ b/example/helm_vars/no-secret.yaml.dec
@@ -1,0 +1,2 @@
+not:
+	a: "secret"

--- a/example/helm_vars/projectX/production/us-east-1/java-app/another-secret.yml
+++ b/example/helm_vars/projectX/production/us-east-1/java-app/another-secret.yml
@@ -1,0 +1,31 @@
+secret_production_projectx: ENC[AES256_GCM,data:NUSh2U7MeE9Ilg6zuUk=,iv:CVAqiUQV460zJ2J2RCcbvwxWbkF0tomXz/GI24RuDXE=,tag:lpCPR5jXR9t6tNh5HzxQrA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2019-03-29T11:02:08Z'
+    mac: ENC[AES256_GCM,data:IygJhBcNtb+3hb0J/DlY01XWYZFfwGQxfXGCuYiqFiMreZ91RL8PATfuQsOuUqLQdubuFJnnCGxW1rNwpqIXaUPjTN1IjUs031ALs3VSu+GGmAm9VL37d4dBbP3m4YYzhgV5m/Mn5Z19H59KcxjaLuujIBaPDztgOn211Ijkui8=,iv:kQDdkQODDg58vYXG90XjuM1ATzYHBCC7Lem5/pllX5E=,tag:MbJuvLqLW57RO/2C5g4wVA==,type:str]
+    pgp:
+    -   created_at: '2019-03-29T11:02:08Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAxYpv4YXKfBAARAAAA8gRfuMZviZ+4kpzEOafKYT7kQ6QSqd/TGdgiZHtJFl
+            p5X0L8NJgXcgr6TNuBQF8f2AUy2IA0lfPfgESMofRD510Js0c7+W8YCrdIIV2kt7
+            wgqrzGFJAMmdbfOyFPCCYQJ/4HEolRvyxuDDfVPcNFxbiPqVeTnPCEZ0fMmsm26o
+            0XWDdKJ7qz5fDA/pi/9zDOsH5nBgksXpdlLGCUjGb1256FadIeYyX1L7ZFDW7jm9
+            IvwU9TQUlJFQ/VPsJPoahPujIVcgRyFSi14vUd9tYglr8cLnJJlFpD1rnb/plKea
+            O1mu7HYQFAdHmCHNtaooHD1tIsrZbCT8SG1qDOif3q8hCDFdLh9QknljTAu/pi3r
+            OMR3opOxw+0ZOFKwaum4iBEG2bDLvDAF574r0HwLWrRvYFvPQLM/ZE9tB6KPBaD4
+            iCm94HgUAPJsVSuuGXRpkkzixGVf3Ozt3CE4Sv3FFwtTBoCFGJxzAQVoYvjaXDjA
+            jZwFTfJoCMmXoq3tHoTEdTJdtvaoGXk2N8n7BZhwhj8jnOftFjhGUaJZggvC2qGT
+            00IqROarjKpoErVvcVxkgPpFa4HLyhNRBdaU3ECet4dNslM+P4j/i1ojNn1BYfG+
+            U5tXFyzp/vQd4MVVhLC+vyGLgQovwm1LXzghsXFHJYICaPewU0ad+qNZGozZjHrS
+            4AHknsSb6QLyJKL6Pn5g/nvrfeEBZeDU4KHh3tHgYuKCnFxp4KTlOoLn0zq7FF7V
+            icU1zn8CpnjF7Y7ofwDhVdgUjnzdQRvgKuSsDnaoZig1t/y9Si1YaEsx4jXbVnjh
+            fREA
+            =rpBY
+            -----END PGP MESSAGE-----
+        fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0

--- a/example/helm_vars/projectX/production/us-east-1/java-app/no-secret.yaml.dec
+++ b/example/helm_vars/projectX/production/us-east-1/java-app/no-secret.yaml.dec
@@ -1,0 +1,2 @@
+not:
+	a: "secret"

--- a/example/helm_vars/projectX/sandbox/us-east-1/java-app/another-secret.yml
+++ b/example/helm_vars/projectX/sandbox/us-east-1/java-app/another-secret.yml
@@ -1,0 +1,31 @@
+secret_sandbox_projectx: ENC[AES256_GCM,data:KSZG/XTW6Wy6RPJ5zIQMTA==,iv:1CbKkKCtk9ze6wmwK6rvfiZcjM6KuCFGUnc6JjtbXR4=,tag:heTaPsUsr2BtkasZ1Zj+/g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2019-03-29T11:02:07Z'
+    mac: ENC[AES256_GCM,data:lGMVD/vMAQ1tC9nwhnskvDE+D9EDe6v/XfAu4MXZWLDaA4gpNgYCJTEvAihVoJIO4jxsbIlzvq35GDRu+mMQMRcxrBK584ZPLv8CXxFRCrfNHOpkKwY3GEQXsLBMq9zUtayYihijR72xyDKoOVpj+zEADwwRIK34/EWN7ht5d8Q=,iv:r2ObjVV9etc1qlv08C35b52kx42ZoVbJluVMA2h/iFk=,tag:WRN2uoL/J9frpaMNSVqUxg==,type:str]
+    pgp:
+    -   created_at: '2019-03-29T11:02:07Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAxYpv4YXKfBAARAAUCaamEEJbGWhWCiIiOeWGaKJYzd/FkC5Qvvv3yFl4YKt
+            6apRMA1/7u9nTEGzVnsH6CwgoU276Fj4oKjOiDuKdaTwEHC1gWZNT5EOll0Jh6ED
+            oQ2rAWexkk/A6hyGdn7tAh/7IAMQK5QIHI0Z+H88DPV8ZfbEC6NRlyepP/LUt92S
+            eVoH1aeUVyTEJVOwmvkKSkAEeQlP+iLJFOECyVO0T5NfnPj8E7OFvJ8Nv5kD1vec
+            wdYVfbRUIZwIySE6alduz2cjxuUBhpbLjMqIT25pL5uXoSzIrxKmvkVg1DInYYJ/
+            1radpOYIGJRJ1aMMfBYtNsL5rSRRjexiykgCm+ZG54SvUbnA8/KfsZLZiZqSxduD
+            k6YX8BAL6WzknJ0qjY3SxZ3tpu6FPBJH9U69z2sM0hFxXCBLOWfsQ3JXpQ+HKRUX
+            c4mlA3lBeOCLVefrJuhy1TjO9094yTEc/i+r9yG7xvLwzWlFSeFpf6ph0vvK+bYG
+            ITglOP9Ipy0T5cTzlKq3pCCLlBAUSRiVncHhspfnoFSSlTgN2kawbikpF1a7I/Qh
+            Mpe29nPBywq4LFzyOJrpOAD6n1HU+KQKp3qZCjhdxx8EawFlZqUF6j7qLkKTN1AQ
+            w43l9pfqS2FXVXuouLlqPcg/KjG+5lx+KFjb1l6cvpvtL0Jvr8YiJ64t75GLoPPS
+            4AHkTeYCfXmj7nRhZWZCuGVaxOFlCeDv4CjhyKfgr+IOF56v4NzlwZRMyKuOnr6R
+            0G8vX7H5t8XJPbUsgB99we6hRY911ZzgAORsusuyK6Aiv2+b58CnLXMp4huU1rTh
+            9L4A
+            =eUDm
+            -----END PGP MESSAGE-----
+        fp: 4434EA5D05F10F59D0DF7399AF1D073646ED4927
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0

--- a/example/helm_vars/projectX/sandbox/us-east-1/java-app/no-secret.yaml.dec
+++ b/example/helm_vars/projectX/sandbox/us-east-1/java-app/no-secret.yaml.dec
@@ -1,0 +1,2 @@
+not:
+	a: "secret"

--- a/example/helm_vars/projectY/production/us-east-1/java-app/another-secret.yml
+++ b/example/helm_vars/projectY/production/us-east-1/java-app/another-secret.yml
@@ -1,0 +1,31 @@
+secret_production_projecty: ENC[AES256_GCM,data:0jcFuH/OjCjnXmaH6lM=,iv:i3KOj0uQPazU87Jb2T8RD7f3eUrKXOW9OsICuB4Rmco=,tag:VsrWeUmMiEgP/ZZvk7BrzQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2019-03-29T11:02:10Z'
+    mac: ENC[AES256_GCM,data:l8MS+OjSUrbaoIdlp7HxzPE3ApNyjxlK7ojuHdyjvBXXYUDuZ5gpLMtaeXxgjKNQaGtIeVOevpiENzOANkL7Hn+MtUJmmeTu7bx1hPQyxebGyLH/Y4DVAM8rY4mGZngTg4LYZcHuL3j9HBIUkf3WLSTqjYFMcbuDKqCCOPuyQf0=,iv:lSAmW9OPRoJeaNAtXFB7u/SPPIPfNJrIgUCD6yoBuR8=,tag:s2KAjECP055ZgDYBoagz5w==,type:str]
+    pgp:
+    -   created_at: '2019-03-29T11:02:10Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAxzSiC7ZHNQZARAATDA+rolBbJrsHLGqgjGDjFANuSiqQOcSYKRF5kFCi1Yj
+            dhHbH5psqVJmdsLQzQDrO5Lrx1Sq8vSzlj5rOA1wMnWbE8M+BzZt4vkvwMw3FOgO
+            IMco/FZUlSUUKe3V2pvMhax9BieJMgFVDYxEB4KI0EeZhqbC/wwGrK+7X0zni7bE
+            jdRhIZ1Xtci6gf24/i5ttA0jc8pRKcFouVJdAz5g79AbcK3Nxph+LlrKNliwRjYc
+            zFs6vnwOR+fOCpCdK9aJY1zG02I1OitRjXKfQUzbsjIG/o4P5gwxuyTm87mWl9Ov
+            rt1vxXWX8EVSBgYfTPC6Oq+gESl47wECGJflun+hlxD06k/16/Pvk6CtQBYF65ss
+            mZb+YAXtck6cxMPuBVaD3L6zs3tvWMl+fdaJb5CAXQLPsXAoOuN9yXCbd9+T1rLo
+            Y6Kn9ZoxTEJk+zN8VAhBuE0aZ/ktmaVXwU98NimuOXTbVt+9noXfgbzRMi+kPui6
+            SXg0IgSwOCSR/oRMk5gqgr3v2LKwMDw/2gdxxTTjCv4x/Mjaz4zmVIqTHM+oR0F/
+            eER4EgVFFN2N5QxcMU3NgGaPgq067F+xOlb1VlXnvxANMEoE9Vcp+nD2aVtsEX+t
+            5egy4xdJzhSIovWjxq4Y9QF0qRp52NYuOkDeadY/XavEjyTBLmp2AF0tpjwcPqbS
+            4AHkyZ1LXa8ja6zN9lCl8gAPWOHDS+Bl4PnhCOrgOuJQ8tNI4FblAT5gFlx5vTIb
+            +AGwfNODVhnB6QJywpHozYV5hxAWYCfgDuQLEaOpis7ypp483Gv9UqwO4tELnnnh
+            ZQMA
+            =Pb7g
+            -----END PGP MESSAGE-----
+        fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0

--- a/example/helm_vars/projectY/production/us-east-1/java-app/no-secret.yaml.dec
+++ b/example/helm_vars/projectY/production/us-east-1/java-app/no-secret.yaml.dec
@@ -1,0 +1,2 @@
+not:
+	a: "secret"

--- a/example/helm_vars/projectY/sandbox/us-east-1/java-app/another-secret.yml
+++ b/example/helm_vars/projectY/sandbox/us-east-1/java-app/another-secret.yml
@@ -1,0 +1,31 @@
+secret_sandbox_projecty: ENC[AES256_GCM,data:AC3dznJbIJBZ7/r6kw2U,iv:uVeNY1dzRAvjyKqahhy2OrqI8sxWeLTqhOMdtVN3X30=,tag:qAImwVgVBnr4lwnS1Yu3iQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2019-03-29T11:02:09Z'
+    mac: ENC[AES256_GCM,data:aZIT/mClu2sx36vpRxzRRtlS3WM+2Qkb1mlhjhHjdrU1NqITFTPyBSemvilpxiF1bUdT5M8Y32dtRFoylsAnZ+w60DvaRynAOm2jL0PSzFq0iLo5W8oUWSPFmJv+/Ixc7SLtKpfjJO9qEt8ad0SipEHEFHc6gKpxMgMIDrbIeWc=,iv:0k7k++pPOFqDXNvOUYbt39MgkW0s2j5a7SnYcaK6WnA=,tag:hx7MixPps3ps7dThnJgcIw==,type:str]
+    pgp:
+    -   created_at: '2019-03-29T11:02:09Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAxzSiC7ZHNQZARAACg4g710ru5aOFnrsOTnoUqvrdbGVTcfOqn7Pk25RmGyH
+            r6hS/zwdB9rbxGhWSiUFHXIpKFecJ6ste9/MuwdYtyvWC1On7ZtaOb0iGo4Oa8zu
+            EZBtB+yeQYvxfNMef6ibnf4H2IALVccyTJq406QDUSRIoAsrKLI5vKqzyEsrAKbS
+            q8TweMV7L0JySCZa9B+zyof1Y8kMjizu3ldQZiwDc63LhpUuxMkoki+2YIcB0Svx
+            Mm+/emXeLBfyBYjyOMUTStVh+J82Nm6nlCD1TgUgfJUwWKGKNzmRPQaUZCY2HSNf
+            PoW4cpw0xtfNCzQL84xL7Cgz9b+jqeMQcSeTvGS/viZaFgln84ISVQ8nz/64IxS7
+            iRu6uYM92PpIqCZcuLgT3O2yL1e91+amr1UMViGLG4dOFspu8dBpUQYGgqr6wrtq
+            acBfiv8iihXZNLfAooCd1XGFE0b5XZ7C4e10PoAYjNg+cLtbRyh1rHhWPBX55BY8
+            bFLKAJIV49hIZf7KUuaQcXi4+oBM/Gyc0ZzT147iZZdWnJ7NGz7Yn/WB7ITqWrUy
+            OLhRTqEn4hvKnpIlNBzlv0Z3TWhiJhw6tRZYGts3/FLEnFq646oAjbxNxcKlf3xK
+            ASkuJ1uNuFFZLbuTzLSrCOq/H28rBkUFP2xDQQ1eSYdAnkE0MXF+Twda8dSPdQ7S
+            4AHkT7zdy5tUboxpmy9Kbs7E1+GzC+DG4MDhzmPgmOLdijXG4JzlxpCjUfI0icOx
+            BAL7hSieSssfq9NAW9waO0h4RZhznmHgjuQ4n27UVdWR6+iqD/TCQHq14nRsowLh
+            tOYA
+            =0z0k
+            -----END PGP MESSAGE-----
+        fp: 40B6FAEC80FD467E3FE9421019F6A67BB1B8DDBE
+    unencrypted_suffix: _unencrypted
+    version: 3.2.0

--- a/example/helm_vars/projectY/sandbox/us-east-1/java-app/no-secret.yaml.dec
+++ b/example/helm_vars/projectY/sandbox/us-east-1/java-app/no-secret.yaml.dec
@@ -1,0 +1,2 @@
+not:
+	a: "secret"

--- a/secrets.sh
+++ b/secrets.sh
@@ -248,9 +248,8 @@ encrypt_helper() {
     local yml=$(basename "$1")
     cd "$dir"
     [[ -e "$yml" ]] || { echo "File does not exist: $dir/$yml"; exit 1; }
-    local ymldec=$(sed -e "s/\\.yaml$/${DEC_SUFFIX}/" <<<"$yml")
+    local ymldec=$(sed -e "s/\\.y\(a\|\)ml$/${DEC_SUFFIX}/" <<<"$yml")
     [[ -e $ymldec ]] || ymldec="$yml"
-    
     if [[ $(grep -C10000 'sops:' "$ymldec" | grep -c 'version:') -gt 0 ]]
     then
 	echo "Already encrypted: $ymldec"
@@ -305,7 +304,7 @@ decrypt_helper() {
 	echo "Not encrypted: $yml"
 	__ymldec="$yml"
     else
-	__ymldec=$(sed -e "s/\\.yaml$/${DEC_SUFFIX}/" <<<"$yml")
+	__ymldec=$(sed -e "s/\\.y\(a\|\)ml$/${DEC_SUFFIX}/" <<<"$yml")
 	if [[ -e $__ymldec && $__ymldec -nt $yml ]]
 	then
 	    echo "$__ymldec is newer than $yml"
@@ -374,7 +373,7 @@ clean() {
 	return
     fi
     local basedir="$1"
-    find "$basedir" -type f -name "secrets*${DEC_SUFFIX}" -exec rm -v {} \;
+    find "$basedir" -type f -name "*secret*${DEC_SUFFIX}" -exec rm -v {} \;
 }
 
 helm_wrapper() {


### PR DESCRIPTION
Hi,

the restrictions on the secret names are very counter-intuitive. e.g.:

```
helm secrets dec secrets.yml
Decrypting secrets.yml
sops metadata not found
Error: plugin "secrets" exited with error
```
this fails, because `yml` is not supported. Additionally, the secret gets deleted with this :(

Currently the secret has to conform the following regex:
^secrets(\.[^.]+)*\.yaml$

This pull request removes the restriction completely and allows any *.yml / *.yaml to be processed.
Instead of relying on the filename the content of the file is checked to verify that it is a sops encrypted file.

Resolves #124, resolves #128 