### PR TITLE
Deprecation of helm-secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![GitHub issues](https://img.shields.io/github/issues/zendesk/helm-secrets.svg)](https://github.com/zendesk/helm-secrets/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/zendesk/helm-secrets.svg?style=flat-square)](https://github.com/zendesk/helm-secrets/pulls)
 
+# Deprecation information 
+
+Please note, this project is no longer being maintained.
+There is a active fork [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets) and we will also contribute our changes to it. 
+
 # Plugin for secrets management in Helm
 
 Developed and used in all environments in [BaseCRM](https://getbase.com/).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Deprecation information 
 
 Please note, this project is no longer being maintained.
-There is a active fork [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets) and we will also contribute our changes to it. 
+There is a active fork [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets) and we will also contribute our future changes to it. 
 
 # Plugin for secrets management in Helm
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Deprecation information 
 
 Please note, this project is no longer being maintained.
-There is a active fork [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets) and we will also contribute our future changes to it. 
+There is an active fork [jkroepke/helm-secrets](https://github.com/jkroepke/helm-secrets) and we will also contribute our future changes to it. 
 
 # Plugin for secrets management in Helm
 

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -83,3 +83,7 @@ else
     echo -e "${RED}[FAIL]${NOC} Install git command"
     exit 1
 fi
+
+echo "Deprecation Info"
+echo "  Please note, this project is no longer being maintained."
+echo "  Link to active helm-secret plugin could be found in helm documentation: https://helm.sh/docs/community/related/#helm-plugins"


### PR DESCRIPTION
As we started use different method to provisioning and maintenance Kubernetes manifest, we decided to freeze future development of this project. There is active fork [#167 ](https://github.com/jkroepke/helm-secrets) which could be used.